### PR TITLE
Fix template indentation and stale colspan in modules confirm page

### DIFF
--- a/htdocs/modules/system/templates/admin/system_modules_confirm.tpl
+++ b/htdocs/modules/system/templates/admin/system_modules_confirm.tpl
@@ -13,18 +13,18 @@
                     <td>
                         <{$row.oldname}>
                         <{if $row.oldname != $row.newname}>
-                        <span class="bold red">&nbsp;&raquo;&nbsp;<{$row.newname}></span>
+                            <span class="bold red">&nbsp;&raquo;&nbsp;<{$row.newname}></span>
                         <{/if}>
                         <input type="hidden" name="module[]" value="<{$row.mid}>"/>
                         <input type="hidden" name="oldname[<{$row.mid}>]" value="<{$row.oldname}>"/>
                         <input type="hidden" name="newname[<{$row.mid}>]" value="<{$row.newname}>"/>
                     </td>
                 </tr>
-                <{/foreach}>
+            <{/foreach}>
             </tbody>
             <tfoot>
             <tr class="txtcenter foot">
-                <td colspan="3">
+                <td>
                     <input class="formButton" type="submit" value="<{$smarty.const._AM_SYSTEM_MODULES_SUBMIT}>"/>&nbsp;
                     <input class="formButton" type="button" value="<{$smarty.const._AM_SYSTEM_MODULES_CANCEL}>"
                            onclick="location='admin.php?fct=modulesadmin'"/>
@@ -39,11 +39,11 @@
 <{else}>
     <div id="xo-module-log">
         <{if isset($result)}>
-        <div class="logger">
-            <{foreach item=row from=$result|default:null}>
-            <div class="spacer"><{$row}></div>
-            <{/foreach}>
-        </div>
+            <div class="logger">
+                <{foreach item=row from=$result|default:null}>
+                    <div class="spacer"><{$row}></div>
+                <{/foreach}>
+            </div>
         <{/if}>
         <a href="admin.php?fct=modulesadmin"><{$smarty.const._AM_SYSTEM_MODULES_BTOMADMIN}></a>
     </div>


### PR DESCRIPTION
## Summary
- Remove stale `colspan="3"` — table is now single-column after PR #1631 cleanup
- Fix `<span>` indentation inside `<{if}>` block
- Fix `<{/foreach}>` alignment to match its opening tag
- Fix logger section indentation to be consistent with parent nesting

These are minor follow-up fixes to the dead code removal in XOOPS/XoopsCore25#1631.

🤖 Generated with [Claude Code](https://claude.com/claude-code)